### PR TITLE
Mansonry is not the same as Masonry

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,4 +51,4 @@ pytest-cov = "^3.0.0"
 
 [build-system]
 requires = ["poetry_core>=1.0", "setuptools"]
-build-backend = "poetry.core.mansonry.api"
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
mansonry, British English, noun, mansions or dwelling places collectively.
masonry, uncountable noun, masonry is bricks or pieces of stone which have been stuck together with cement as part of a wall or building.