### PR TITLE
Don't make python2-wheel

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,4 +9,4 @@ tag = True
 license_file = LICENSE
 
 [bdist_wheel]
-universal = 1
+universal = 0


### PR DESCRIPTION
https://buildmedia.readthedocs.org/media/pdf/wheel/stable/wheel.pdf:
````
If you want to make universal (Python 2/3 compatible, pure Python) wheels, add the following section to your setup.
cfg:
[bdist_wheel]
universal = 1
````